### PR TITLE
Let's add some logs to investigate scheduling issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
 - '2.7'
 
-sudo: required
+dist: trusty
+os: linux
+
 before_install:
 - jdk_switcher use oraclejdk8
 

--- a/src/main/java/org/apache/aurora/scheduler/scheduling/TaskAssignerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/scheduling/TaskAssignerImpl.java
@@ -235,6 +235,8 @@ public class TaskAssignerImpl implements TaskAssigner {
             o -> !matchesByOffer.containsKey(o.getOffer().getId().getValue())
                 && !isAgentReserved(o, groupKey, preemptionReservations));
 
+        LOG.info("After filtering reserved offers, we have {} offers for {}.", Iterables.size(matchingOffers), groupKey.toString());
+
         chosenOffer = Optional.ofNullable(Iterables.getFirst(matchingOffers, null));
       }
 


### PR DESCRIPTION
This will print number of offers Aurora received and how many offers there are after filtering. We may want to add more info later if it looks like a good lead to understand lack of schedulability.